### PR TITLE
Removes secret uniqueness checks

### DIFF
--- a/ceremonySchema.json
+++ b/ceremonySchema.json
@@ -61,15 +61,13 @@
                             "type": "array",
                             "items": {
                                 "$ref": "#/$defs/G1Point"
-                            },
-                            "uniqueItems": true
+                            }
                         },
                         "potPubkeys": {
                             "type": "array",
                             "items": {
                                 "$ref": "#/$defs/G2Point"
-                            },
-                            "uniqueItems": true
+                            }
                         }
                     },
                     "required": [
@@ -130,15 +128,13 @@
                             "type": "array",
                             "items": {
                                 "$ref": "#/$defs/G1Point"
-                            },
-                            "uniqueItems": true
+                            }
                         },
                         "potPubkeys": {
                             "type": "array",
                             "items": {
                                 "$ref": "#/$defs/G2Point"
-                            },
-                            "uniqueItems": true
+                            }
                         }
                     },
                     "required": [
@@ -199,15 +195,13 @@
                             "type": "array",
                             "items": {
                                 "$ref": "#/$defs/G1Point"
-                            },
-                            "uniqueItems": true
+                            }
                         },
                         "potPubkeys": {
                             "type": "array",
                             "items": {
                                 "$ref": "#/$defs/G2Point"
-                            },
-                            "uniqueItems": true
+                            }
                         }
                     },
                     "required": [
@@ -268,15 +262,13 @@
                             "type": "array",
                             "items": {
                                 "$ref": "#/$defs/G1Point"
-                            },
-                            "uniqueItems": true
+                            }
                         },
                         "potPubkeys": {
                             "type": "array",
                             "items": {
                                 "$ref": "#/$defs/G2Point"
-                            },
-                            "uniqueItems": true
+                            }
                         }
                     },
                     "required": [

--- a/coordinator.md
+++ b/coordinator.md
@@ -50,20 +50,6 @@ def non_zero_check(ceremony: Ceremony) -> bool:
             return False
     return True
 ```
-- __Pubkey uniqueness__ - Check that there are no duplicate `pot_pubkey`s across all the `Transcript`s.
-
-```python
-def pubkey_uniqueness_check(ceremony: Ceremony) -> bool:
-    '''
-    Note: pubkeys MUST be unique across all transcripts
-    Note: This algorithm (comparing bit-representations) suffices iff the pubkeys are stored in affine co-ordinates.
-          If projective coordinates are used, then pubkeys must be compared using bls.G2.is_equal()
-    '''
-    pubkeys = []
-    for transcript in ceremony.transcripts:
-        pubkeys += transcript.witness.pot_pubkeys
-    return len(pubkeys) == len(list(set(pubkeys)))
-```
 
 - __Witness continuity check__ - Check that the witness has not been tampered with by the coordinator. This is done by checking that the newly received ceremony's witnesses overlap with the previous ceremony's witnesses in all but the last location where an honest participant would have added their contribution.
 


### PR DESCRIPTION
Made the decision to remove the "PubKey Uniqueness" check. The idea was to prevent malicious participants from using the same secret both between the sub-ceremonies and between various participation instances. Fixes #2.

That said, this is being removed due to the following issues:
1. It doesn't change the fundamental trust assumption, we are still reliant on a single honest participant.
2. A malicious participant could subvert the check by participating with different factors of a secret that has the same product.
3. It is an annoying check to perform as it is the only inter-sub-ceremony check.