### PR TITLE
Makes extra explcit what the subgroup checks verify

### DIFF
--- a/BLS.md
+++ b/BLS.md
@@ -4,8 +4,10 @@
 
 We make use of the following notation throughout this specification:
 - $p$ - the field modulus
-- $\mathbb{G}_1 \subset E_1(\mathbb{F}_p)$ - the additive subgroup of the curve defined over $\mathbb{F}_p$
-- $\mathbb{G}_1 \subset E_2(\mathbb{F}_{p^2})$ - the additive subgroup of the curve defined over $\mathbb{F}_{p^2}$
+- $E_1(\mathbb{F}_p)$ the curve defined over $\mathbb{F}_p$
+- $E_2(\mathbb{F}_p^2)$ the curve defined over $\mathbb{F}_{p^2}$
+- $\mathbb{G}_1 \subset E_1(\mathbb{F}_p)$ - the prime-ordered additive subgroup of $E_1(\mathbb{F}_p)$
+- $\mathbb{G}_1 \subset E_2(\mathbb{F}_{p^2})$ - the prime-ordered additive subgroup of $\mathbb{F}_{p^2}$
 - $g_1 \in \mathbb{G}_1$, $g_2 \in \mathbb{G}_2$  - the generators of $\mathbb{G}_1$ and $\mathbb{G}_2$ respectively
 - $\mathcal{O}_1 \in \mathbb{G}_1$, $\mathcal{O}_2 \in \mathbb{G}_2$  - the points at infinity for $\mathbb{G}_1$ and $\mathbb{G}_2$ respectively
 - $e: \mathbb{G}_1 \times \mathbb{G}_2 \to \mathbb{G}_T$ - the bilinear pairing function 
@@ -42,7 +44,7 @@ Implementations making use of the IRTF BLS Standards SHOULD choose the `BLS_POP_
 - `bls.G1.add(P, Q)` - EC group addition of points `P` and `Q` $\in \mathbb{G}_1$, returns a $\mathbb{G}_1$ point.
 - `bls.G1.mul(x, P)` - Scalar multiplication of point `P` by `x` $\in \mathbb{F}_r$, returns a $\mathbb{G}_1$ point.
 - `bls.G1.is_inf(P)` - Returns `True` if `P` $=\mathcal{O}_1$, `False` otherwise
-- `bls.G1.is_in_G1(P)` - $\mathbb{G}_1$ subgroup check. Returns `True` if `P` $\in\mathcal{G}_1$, `False` otherwise
+- `bls.G1.is_in_prime_subgroup(P)` - $\mathbb{G}_1$ prime-ordered subgroup check. Returns `True` if `P` $\in\mathcal{G}_1$, `False` otherwise
 
 ### G2
 
@@ -50,7 +52,7 @@ Implementations making use of the IRTF BLS Standards SHOULD choose the `BLS_POP_
 - `bls.G2.add(P, Q)` - EC group addition of points `P` and `Q` $\in \mathbb{G}_2$, returns a $\mathbb{G}_2$ point.
 - `bls.G2.mul(x, P)` - Scalar multiplication of point `P` by `x` $\in \mathbb{F}_r$, returns a $\mathbb{G}_2$ point.
 - `bls.G2.is_inf(P)` - Returns `True` if `P` $=\mathcal{O}_2$, `False` otherwise
-- `bls.G2.is_in_G2(P)` - $\mathbb{G}_2$ subgroup check. Returns `True` if `P` $\in\mathcal{G}_2$, `False` otherwise
+- `bls.G2.is_in_prime_subgroup(P)` - $\mathbb{G}_2$ prime-ordered subgroup check. Returns `True` if `P` $\in\mathcal{G}_2$, `False` otherwise
 
 ### Pairing
 

--- a/coordinator.md
+++ b/coordinator.md
@@ -23,21 +23,21 @@ def schema_check(transcript_json: str, schema_path: str) -> bool:
 
 ### Point Checks
 
-- Subgroup checks
-    - __G1 Powers Subgroup check__ - For each of the $\mathbb{G}_1$ Powers of Tau (`g1_powers`), verify that they are actually elements of the subgroup.
-    - __G2 Powers Subgroup check__ - For each of the $\mathbb{G}_2$ Powers of Tau (`g2_powers`), verify that they are actually elements of the subgroup.
-    - __Witness Subgroup checks__ - For each of the points in `witness`, check that they are actually elements of their respective subgroups.
+- Prime Subgroup checks
+    - __G1 Powers Subgroup check__ - For each of the $\mathbb{G}_1$ Powers of Tau (`g1_powers`), verify that they are actually elements of the prime-ordered subgroup.
+    - __G2 Powers Subgroup check__ - For each of the $\mathbb{G}_2$ Powers of Tau (`g2_powers`), verify that they are actually elements of the prime-ordered subgroup.
+    - __Witness Subgroup checks__ - For each of the points in `witness`, check that they are actually elements of their respective prime-ordered subgroups.
 
 ```python
 def subgroup_checks(transcript: Transcript) -> bool:
     for sub_ceremony in transcript.sub_ceremonies:
-        if not all(bls.G1.is_in_G1(P) for P in sub_ceremony.powers_of_tau.g1_powers):
+        if not all(bls.G1.is_in_prime_subgroup(P) for P in sub_ceremony.powers_of_tau.g1_powers):
             return False
-        if not all(bls.G2.is_in_G2(P) for P in sub_ceremony.powers_of_tau.g2_powers):
+        if not all(bls.G2.is_in_prime_subgroup(P) for P in sub_ceremony.powers_of_tau.g2_powers):
             return False
-        if not all(bls.G1.is_in_G1(P) for P in sub_ceremony.witness.running_products):
+        if not all(bls.G1.is_in_prime_subgroup(P) for P in sub_ceremony.witness.running_products):
             return False
-        if not all(bls.G2.is_in_G2(P) for P in sub_ceremony.witness.pot_pubkeys):
+        if not all(bls.G2.is_in_prime_subgroup(P) for P in sub_ceremony.witness.pot_pubkeys):
             return False
     return True
 ```

--- a/participant.md
+++ b/participant.md
@@ -51,9 +51,9 @@ def schema_check(transcript_json: str, schema_path: str) -> bool:
 #### Point Checks
 
 - Subgroup checks
-    - __G1 Powers Subgroup check__ - For each of the $\mathbb{G}_1$ Powers of Tau (`g1_powers`), verify that they are actually elements of the subgroup.
-    - __G2 Powers Subgroup check__ - For each of the $\mathbb{G}_2$ Powers of Tau (`g2_powers`), verify that they are actually elements of the subgroup.
-    - __Running Product Subgroup check__ - Check that the last running product (the one the participant will interact with) is an element of the subgroup.
+    - __G1 Powers Subgroup check__ - For each of the $\mathbb{G}_1$ Powers of Tau (`g1_powers`), verify that they are actually elements of the prime-ordered subgroup.
+    - __G2 Powers Subgroup check__ - For each of the $\mathbb{G}_2$ Powers of Tau (`g2_powers`), verify that they are actually elements of the prime-ordered subgroup.
+    - __Running Product Subgroup check__ - Check that the last running product (the one the participant will interact with) is an element of the prime-ordered subgroup.
 
 ```python
 def subgroup_checks(transcript: Transcript) -> bool:

--- a/sdk.md
+++ b/sdk.md
@@ -56,7 +56,7 @@ function updateTranscript(oldTranscript: Transcript, secrets: string[]): Transcr
 
 ### `transcriptSubgroupCheck`
 
-This function performs the subgroup checks as described in [`participant.md`](./participant.md). Should all the subgroup checks in every transcript pass, this function returns `true`.
+This function performs the prime-ordered subgroup checks as described in [`participant.md`](./participant.md). Should all the subgroup checks in every transcript pass, this function returns `true`.
 
 ```typescript
 function transcriptSubgroupCheck(transcript: Transcript): boolean {


### PR DESCRIPTION
In order to ensure absolute clarity on what is being checked in the "Subgroup checks" this PR renames `is_in_G1` to `is_in_prime_subgroup`