### PR TITLE
Rename Coordinator to Sequencer

### DIFF
--- a/API/clientApi.yml
+++ b/API/clientApi.yml
@@ -141,7 +141,7 @@ paths:
       tags:
       - Queue
       summary: Check-in and request queue status
-      description: Check-in with the coordinator, thus confirming the client's liveness.
+      description: Check-in with the sequencer, thus confirming the client's liveness.
         Response will include next check-in time, and a notification to start the
         contribution phase, if the participant is at the head of the queue.
       requestBody:

--- a/API/clientApiSpec.md
+++ b/API/clientApiSpec.md
@@ -57,15 +57,15 @@ Should the queue be empty when `queue/join` is called, the status will indicate 
 
 A participant may leave the queue voluntarily by calling the `queue/leave` end point. Clients should issue this call if the user is intentionally leaving. The participant will be removed in any case once they fail to check in.
 
-### Coordinator
+### Sequencer
 
-The coordinator will track individual participants, their position in the queue, and their check-in deadlines. The queue will advance every time a computation is completed and verified. Should a participant fail to check in by their deadline (plus an allowance for latency, clock variations, etc.), the participant will be removed from the queue. 
+The sequencer will track individual participants, their position in the queue, and their check-in deadlines. The queue will advance every time a computation is completed and verified. Should a participant fail to check in by their deadline (plus an allowance for latency, clock variations, etc.), the participant will be removed from the queue. 
 
 The expected time to participate will be estimated based on the average round trip computation time (including verification) times the number of waiters ahead in the queue. This will be recalculated with the latest data each time the participant checks in.
 
 The initial check-in deadline will be 2 hours prior to the estimated start time. They will continue with check-ins at an interval of 1 hour or half the expected wait time, whichever is smaller. While the wait time is less than 1 hour, the deadline will be halved at each check-in call, to a minimum of 5 seconds. 
 
-For the participant currently computing their contribution, the coordinator must allow enough time for slow contributors to complete while enforcing on a deadline so as to abort failed or abandoned computations. The deadline will be 3 minutes. During this time, the participant at the head of the queue will poll at 5 second intervals until either the computation is completed or the deadline is reached. 
+For the participant currently computing their contribution, the sequencer must allow enough time for slow contributors to complete while enforcing on a deadline so as to abort failed or abandoned computations. The deadline will be 3 minutes. During this time, the participant at the head of the queue will poll at 5 second intervals until either the computation is completed or the deadline is reached. 
 
 ## The Computation Phase
 

--- a/API/clientREADME.md
+++ b/API/clientREADME.md
@@ -1,4 +1,4 @@
-Some documents in this folder refer to client/coordinator interactions for the KZG ceremony, without detailed reference to the payload (the ceremony data). 
+Some documents in this folder refer to client/sequencer interactions for the KZG ceremony, without detailed reference to the payload (the ceremony data). 
 
 They are:
 ## queueStrategy.md

--- a/API/contributorQualification.md
+++ b/API/contributorQualification.md
@@ -54,9 +54,9 @@ GitHub accounts will be accepted if they have a commit dated prior to 1 August 2
 The GitHub handle will be used as the identifier in the ceremony contribution record. 
 
 
-# Coordinator Handover
+# Sequencer Handover
 
-Handover of the coordinator role will require continued access to the list of all accounts used thus far in the ceremony.
-During handover, the retiring coordinator must export a list of all identifiers, and the new coordinator must import the list.
+Handover of the sequencer role will require continued access to the list of all accounts used thus far in the ceremony.
+During handover, the retiring sequencer must export a list of all identifiers, and the new sequencer must import the list.
 
 

--- a/API/queueStrategy.md
+++ b/API/queueStrategy.md
@@ -16,23 +16,23 @@ valid contributions. However, the ceremony requires a strict chain of contributi
 Participants must qualify by signing in. See [contributor qualification spec](./contributorQualification.md). Once signed in, they may join the queue. From this point,
 the client should remain online until the contribution is complete. 
 
-The queue will be maintained by the coordinator. The queue will advance whenever:
+The queue will be maintained by the sequencer. The queue will advance whenever:
 - a participant completes their contribution, or
 - is determined to have left the queue This will occur if the client fails to check in by the deadline (see [client API spec](./clientApiSpec.md)), or 
 - has taken too long to submit their contribution.  
 
-Contributors who leave the queue (and are detected as such by the coordinator) may not rejoin at a later stage. Contributors may contribute only once. 
+Contributors who leave the queue (and are detected as such by the sequencer) may not rejoin at a later stage. Contributors may contribute only once. 
 Individuals will not be prevented from rejoining under a different ID, subject to passing the anti-sybil tests.
 
 Submissions for all sub-ceremonies will be collected and submitted together. A valid contribution requires all 4 contributions to pass validity tests. (See [ transcript schema spec](./transcriptSchema.json)). 
 
-The coordinator will ensure that no more than a single contributor is contributing at any given time. `Contributing` here refers to the full life-cycle:
+The sequencer will ensure that no more than a single contributor is contributing at any given time. `Contributing` here refers to the full life-cycle:
 - Passing the last valid transcript to the contributor
 - Waiting for the computation to be performed
 - Receiving the updated transcript
-- Validation by the Coordinator
+- Validation by the Sequencer
 - Notifying the next contributor to begin
 
-# Coordinator Handover
+# Sequencer Handover
 
-Handover from one coordinator to another will occur at infrequent, planned intervals over the time span of the ceremony. To facilitate handover, the coordinator is able to stop accepting new entries to the queue, and to halt processing once the queue is exhausted and the last contribution completely processed. 
+Handover from one sequencer to another will occur at infrequent, planned intervals over the time span of the ceremony. To facilitate handover, the sequencer is able to stop accepting new entries to the queue, and to halt processing once the queue is exhausted and the last contribution completely processed. 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Powers of Tau Specification
 These documents comprise a specification for Ethereum's Powers of Tau (PoT) setup for use in [KZG commitments](https://dankradfeist.de/ethereum/2020/06/16/kate-polynomial-commitments.html) in [EIP-4844 (Proto-Danksharding)](https://eips.ethereum.org/EIPS/eip-4844) and ultimately [Full Danksharding](https://notes.ethereum.org/@dankrad/new_sharding).
 
-The ceremony takes place between _participants_ and the _coordinator_.  _Participants_ are the entities that contribute their secret randomness to the final output $\tau$ s. The roll of the _coordinator_ it to act as the common point of interaction for all participants as well as verifying participants' contribution as the ceremony progresses.
+The ceremony takes place between _participants_ and the _sequencer_.  _Participants_ are the entities that contribute their secret randomness to the final output $\tau$ s. The roll of the _sequencer_ it to act as the common point of interaction for all participants as well as verifying participants' contribution as the ceremony progresses.
 
 ## 10'000 ft Overview
 We are performing a ceremony to generate Powers of Tau for KZG proofs on Ethereum. The output of the ceremony consists of 4 (distinct) sets of Powers of Tau each with a different maximum power:
@@ -16,7 +16,7 @@ Due to a lack of standardisation for a complete API for BLS curves, we define ou
 
 ## `contribution.json`
 
-Due to the simplicity of this PoT setup, the full contribution is sent as a json file between the coordinator & participants. This allows the use of a RESTful API between the two and verification of certain aspects of the `contribution.json` file via the [contributionSchema.json](./contributionSchema.json) [JSON schema](https://json-schema.org/).
+Due to the simplicity of this PoT setup, the full contribution is sent as a json file between the sequencer & participants. This allows the use of a RESTful API between the two and verification of certain aspects of the `contribution.json` file via the [contributionSchema.json](./contributionSchema.json) [JSON schema](https://json-schema.org/).
 
 
 ## `Contribution` object

--- a/coordinator.md
+++ b/coordinator.md
@@ -1,6 +1,6 @@
-# Coordinator
+# Sequencer
 
-The primary job of the coordinator is to sequence participants in the ceremony by acting as the point of contact for participants. The coordinator is required to have a DoS-resilient internet connection and sufficiently powerful hardware to verify the transcript rapidly so that they are able to send the transcript to the next participant as soon as possible. Furthermore, the coordinator should be a semi-trusted entity as they have the power to censor participants, although they cannot affect the safety of the setup.
+The primary job of the sequencer is to sequence participants in the ceremony by acting as the point of contact for participants. The sequencer is required to have a DoS-resilient internet connection and sufficiently powerful hardware to verify the transcript rapidly so that they are able to send the transcript to the next participant as soon as possible. Furthermore, the sequencer should be a semi-trusted entity as they have the power to censor participants, although they cannot affect the safety of the setup.
 
 
 ## Transcript object
@@ -35,7 +35,7 @@ class Transcript
 
 ## Verification
 
-Upon receiving the transcript back from a participant, the Coordinator MUST perform the following checks.
+Upon receiving the transcript back from a participant, the Sequencer MUST perform the following checks.
 
 ### Contribution schema structure:
 
@@ -145,7 +145,7 @@ def g2_powers_check(transcript: Transcript) -> bool:
 
 ## Updating the transcript
 
-Once the coordinator has performed the above Verification checks, they MUST update the transcript.
+Once the sequencer has performed the above Verification checks, they MUST update the transcript.
 
 
 ```python
@@ -165,7 +165,7 @@ def update_transcript(old_transcript: Transcript, contribution: Contribution) ->
 
 ## Generating the contribution file for the next participant
 
-Once the transcript has been updated, the coordinator MUST get a new `Contribution` file to send to the next participant.
+Once the transcript has been updated, the sequencer MUST get a new `Contribution` file to send to the next participant.
 
 ```python
 def get_new_contribution_file(transcript: Transcript) -> Contribution:

--- a/participant.md
+++ b/participant.md
@@ -1,6 +1,6 @@
 # Participant
 
-A participatooor downloads the contribution file from the coordinator, mixes their local randomness into the SRS and returns the contribution to the coordinator who then verifies that the contributor did not contribute in a malicious* manner.
+A participatooor downloads the contribution file from the sequencer, mixes their local randomness into the SRS and returns the contribution to the sequencer who then verifies that the contributor did not contribute in a malicious* manner.
 
 ## Generating randomness
 
@@ -29,7 +29,7 @@ A good method for meeting the above requirements would be to make use of the `Ke
 
 ### Verifying the contribution file
 
-In order to ensure that the coordinator is not tricking a participant into leaking some of the entropy they are contributing, the participant SHOULD perform the following checks:
+In order to ensure that the sequencer is not tricking a participant into leaking some of the entropy they are contributing, the participant SHOULD perform the following checks:
 
 
 #### Contribution file structure:


### PR DESCRIPTION
As decided in the Discord chat, we are renaming the Coordinator as the Sequencer as that more accurately describes what the role is and doesn't have additional control connotations.