### PR TITLE
Update sequencer busy code to 204: No Content

### DIFF
--- a/apiSpec/sequencerApi.yml
+++ b/apiSpec/sequencerApi.yml
@@ -72,7 +72,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Contribution'
+              $ref: 'contributionSchema.json'
       responses:
         200:
           description: successful operation
@@ -126,7 +126,9 @@ paths:
           content:
             application/json:
               schema:
-                type: object
+                $ref: 'contributionSchema.json'
+        204:
+          description: Not ready for contribution. Someone else is currently contributing, try again soon.
   /auth/request_link:
     post:
       tags:
@@ -189,10 +191,6 @@ components:
     CeremonyStatus:
       type: object
       description: Overall ceremony summary metrics
-    Contribution:
-      type: object
-      description: The prior contributor's submission, ready to be updated. Refer
-        to contributionSchema.json for the description of this content.
     ContributionStatus:
       required:
       - id


### PR DESCRIPTION
Currently the sequencer returns a 200 response for both it's time to contribute and please try again. This PR updates the responses as follows:

`204 - No Content` - Request was valid, but someone else is currently contributing.
`200 - OK` - Here is the `contribution.json`, get on it.