### PR TITLE
Updates sequencer domain to `seq.ceremony.ethereum.org`

### DIFF
--- a/apiSpec/sequencerApi.yml
+++ b/apiSpec/sequencerApi.yml
@@ -9,7 +9,7 @@ info:
     url: http://creativecommons.org/publicdomain/zero/1.0/
   version: 1.0.0
 servers:
-- url: https://sequencer.ceremony.ethereum.org
+- url: https://seq.ceremony.ethereum.org
 tags:
   - name: Ceremony
     description: Ceremony progress and status


### PR DESCRIPTION
This change was implemented so as to have a CDN in front of the `/info/` API endpoint as despite the machine being very beefy, @skylenet realised that we could saturate the 10gig line requesting the `current_state`.