### PR TITLE
Removes references to passing the sequencer roll around

### DIFF
--- a/docs/sequencer/contributorQualification.md
+++ b/docs/sequencer/contributorQualification.md
@@ -52,11 +52,3 @@ GitHub accounts will be accepted if they have a commit dated prior to 1 August 2
 
 ### Identifier
 The GitHub handle will be used as the identifier in the ceremony contribution record. 
-
-
-# Sequencer Handover
-
-Handover of the sequencer role will require continued access to the list of all accounts used thus far in the ceremony.
-During handover, the retiring sequencer must export a list of all identifiers, and the new sequencer must import the list.
-
-

--- a/docs/sequencer/queueStrategy.md
+++ b/docs/sequencer/queueStrategy.md
@@ -58,7 +58,3 @@ The sequencer will ensure that no more than a single contributor is contributing
 Once the participant finishes computing their contribution, they call `POST /contribute` with the resulting file.
 If sequencer determines the contribution was valid (see: [sequencer spec](./sequencer.md)), it returns a contribution receipt.
 Otherwise an error is returned. In both cases the participant is blacklisted from joining the lobby and contributing again.
-
-# Sequencer Handover
-
-Handover from one sequencer to another will occur at infrequent, planned intervals over the time span of the ceremony. To facilitate handover, the sequencer is able to stop accepting new participants to the lobby, and to halt processing once the lobby is emptied (either by participants becoming offline or finishing their contributions).


### PR DESCRIPTION
The sequencer roll will no longer be passed around between multiple entities as this adds a bunch of complexity that is almost certainly unwarranted.

The fact that the sequencer can be held accountable because they sign the contribution receipt and that the ceremony will run for long enough that we should be able to detect and address potential issues from this should be sufficient to cover these needs.


Thanks to Ahmet for pointing this out.